### PR TITLE
Refactor Search Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ however you can use your preferred approach to assigning environment variables.
 - **DEV_DB_PATH** - The path to your development mongo instance, for example
 mongodb://127.0.0.1:27017/skillsearch
 - **SESSION_SECRET** - A secret used for session generation
-- **LOGIN_REDIRECT** - This should be http://localhost:3000/profile
 - **TEST_USER** - An email address used for authenticating a user while running tests
 - **TEST_USER_PASSWORD** - A password for authenticating the test user
 - **TEST_USER_2** - A different email address used for authenticating a user while running tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -347,6 +347,14 @@
       "integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -1544,6 +1552,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz",
       "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
     },
     "form-data": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "axios": "^0.21.1",
     "connect-mongo": "^3.2.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",

--- a/services/searchServices.js
+++ b/services/searchServices.js
@@ -23,10 +23,10 @@ const prepareQuery = (query) => {
   if (!permittedLocations.includes(cleanQuery.locationName.toLowerCase())) cleanQuery.locationName = 'london';
 
   // Encoded query
-  const encodedQuery = `keywords=${cleanQuery.keywords}&locationName=${
+  const queryToEncode = `keywords=${cleanQuery.keywords}&locationName=${
     cleanQuery.locationName}&distanceFromLocation=${cleanQuery.distanceFromLocation}`;
 
-  return { encodedQuery: encodeURI(encodedQuery), cleanQueryObject: cleanQuery };
+  return { encodedQuery: encodeURI(queryToEncode), cleanQueryObject: cleanQuery };
 };
 
 /**

--- a/services/searchServices.js
+++ b/services/searchServices.js
@@ -13,40 +13,49 @@ const { permittedLocations } = require('./data/permittedLocations');
  * @return {Object} Returns a Encoded and sanitised query string, and also an object version.
  */
 const prepareQuery = (query) => {
-  const q = query;
+  const cleanQuery = query;
 
-  // Validate that the distance provided is a valid integer, otherwise default to 10
-  const distanceFromLocationAsFloat = parseFloat(q.distanceFromLocation, 10);
-
-  if (Number.isNaN(distanceFromLocationAsFloat)) {
-    q.distanceFromLocation = 10;
-  } else {
-    const distanceFromLocationAsInt = Math.round(distanceFromLocationAsFloat);
-    q.distanceFromLocation = Math.trunc(distanceFromLocationAsInt);
-  }
+  cleanQuery.distanceFromLocation = cleanseDistance(cleanQuery.distanceFromLocation);
 
   // Validate keywords exist in pre-defined list, drop those that do not.
   // These are sorted to allow matching to duplicate saved searches
-  const keywordsArray = q.keywords.split(' ');
+  const keywordsArray = cleanQuery.keywords.split(' ');
   keywordsArray.sort();
-  q.keywords = '';
+  cleanQuery.keywords = '';
 
   keywordsArray.forEach((keyword) => {
     if (permittedKeywords.includes(keyword.toLowerCase())) {
-      q.keywords += `${keyword} `;
+      cleanQuery.keywords += `${keyword} `;
     }
   });
 
-  q.keywords = q.keywords.trim();
+  cleanQuery.keywords = cleanQuery.keywords.trim();
 
   // Validate location exists in pre-defined list, if not default to london
-  if (!permittedLocations.includes(q.locationName.toLowerCase())) q.locationName = 'london';
+  if (!permittedLocations.includes(cleanQuery.locationName.toLowerCase())) cleanQuery.locationName = 'london';
 
   // Encoded query
-  const encodedQuery = `keywords=${q.keywords}&locationName=${
-    q.locationName}&distanceFromLocation=${q.distanceFromLocation}`;
+  const encodedQuery = `keywords=${cleanQuery.keywords}&locationName=${
+    cleanQuery.locationName}&distanceFromLocation=${cleanQuery.distanceFromLocation}`;
 
-  return { encodedQuery: encodeURI(encodedQuery), cleanQueryObject: q };
+  return { encodedQuery: encodeURI(encodedQuery), cleanQueryObject: cleanQuery };
+};
+
+/**
+ * Review the number provided and default (to 10) or round it as required
+ * @param {Number} distance Value for the search distance (miles).
+ * @return {Number} Returns a distance value.
+ */
+const cleanseDistance = (distance) => {
+  const distanceFromLocationAsFloat = parseFloat(distance, 10);
+
+  if (Number.isNaN(distanceFromLocationAsFloat)) {
+    return 10;
+  }
+
+  const distanceRoundedAndTruncated = Math.trunc(Math.round(distanceFromLocationAsFloat));
+
+  return distanceRoundedAndTruncated;
 };
 
 /**

--- a/services/searchServices.js
+++ b/services/searchServices.js
@@ -17,19 +17,7 @@ const prepareQuery = (query) => {
 
   cleanQuery.distanceFromLocation = cleanseDistance(cleanQuery.distanceFromLocation);
 
-  // Validate keywords exist in pre-defined list, drop those that do not.
-  // These are sorted to allow matching to duplicate saved searches
-  const keywordsArray = cleanQuery.keywords.split(' ');
-  keywordsArray.sort();
-  cleanQuery.keywords = '';
-
-  keywordsArray.forEach((keyword) => {
-    if (permittedKeywords.includes(keyword.toLowerCase())) {
-      cleanQuery.keywords += `${keyword} `;
-    }
-  });
-
-  cleanQuery.keywords = cleanQuery.keywords.trim();
+  cleanQuery.keywords = cleanseKeywords(cleanQuery.keywords);
 
   // Validate location exists in pre-defined list, if not default to london
   if (!permittedLocations.includes(cleanQuery.locationName.toLowerCase())) cleanQuery.locationName = 'london';
@@ -56,6 +44,27 @@ const cleanseDistance = (distance) => {
   const distanceRoundedAndTruncated = Math.trunc(Math.round(distanceFromLocationAsFloat));
 
   return distanceRoundedAndTruncated;
+};
+
+/**
+ * Take the string of keywords, ensure they match the list of permitted words and return clean
+ * @param {String} keywords Search terms provided by the user.
+ * @return {String} Returns a cleansed version of the search terms.
+ */
+const cleanseKeywords = (keywords) => {
+  const keywordsArray = keywords.split(' ');
+  keywordsArray.sort();
+  let keywordsToReturn = '';
+
+  keywordsArray.forEach((keyword) => {
+    if (permittedKeywords.includes(keyword.toLowerCase())) {
+      keywordsToReturn += `${keyword} `;
+    }
+  });
+
+  keywordsToReturn = keywordsToReturn.trim();
+
+  return keywordsToReturn;
 };
 
 /**

--- a/services/searchServices.js
+++ b/services/searchServices.js
@@ -71,6 +71,9 @@ const searchReed = async (query) => {
   } catch (error) {
     console.error(error);
   }
+
+  // If we hit an error we return nothing
+  return { totalResults: 0 };
 };
 
 /**

--- a/services/searchServices.js
+++ b/services/searchServices.js
@@ -8,26 +8,6 @@ const { permittedKeywords } = require('./data/permittedKeywords');
 const { permittedLocations } = require('./data/permittedLocations');
 
 /**
- * Build query string for API call
- * @param {Object} query Only keywords, locationName and distanceFromLocation are used.
- * @return {Object} Returns a Encoded and sanitised query string, and also an object version.
- */
-const prepareQuery = (query) => {
-  const cleanQuery = query;
-
-  cleanQuery.distanceFromLocation = cleanseDistance(cleanQuery.distanceFromLocation);
-
-  cleanQuery.keywords = cleanseKeywords(cleanQuery.keywords);
-
-  cleanQuery.locationName = cleanseLocation(cleanQuery.locationName);
-
-  const queryToEncode = `keywords=${cleanQuery.keywords}&locationName=${
-    cleanQuery.locationName}&distanceFromLocation=${cleanQuery.distanceFromLocation}`;
-
-  return { encodedQuery: encodeURI(queryToEncode), cleanQueryObject: cleanQuery };
-};
-
-/**
  * Review the number provided and default (to 10) or round it as required
  * @param {Number} distance Value for the search distance (miles).
  * @return {Number} Returns a distance value.
@@ -76,6 +56,26 @@ const cleanseLocation = (location) => {
   }
 
   return location;
+};
+
+/**
+ * Build query string for API call
+ * @param {Object} query Only keywords, locationName and distanceFromLocation are used.
+ * @return {Object} Returns a Encoded and sanitised query string, and also an object version.
+ */
+const prepareQuery = (query) => {
+  const cleanQuery = query;
+
+  cleanQuery.distanceFromLocation = cleanseDistance(cleanQuery.distanceFromLocation);
+
+  cleanQuery.keywords = cleanseKeywords(cleanQuery.keywords);
+
+  cleanQuery.locationName = cleanseLocation(cleanQuery.locationName);
+
+  const queryToEncode = `keywords=${cleanQuery.keywords}&locationName=${
+    cleanQuery.locationName}&distanceFromLocation=${cleanQuery.distanceFromLocation}`;
+
+  return { encodedQuery: encodeURI(queryToEncode), cleanQueryObject: cleanQuery };
 };
 
 /**

--- a/services/searchServices.js
+++ b/services/searchServices.js
@@ -8,7 +8,7 @@ const { permittedKeywords } = require('./data/permittedKeywords');
 const { permittedLocations } = require('./data/permittedLocations');
 
 /**
- * Build query string, sanitise as needed and encode
+ * Build query string for API call
  * @param {Object} query Only keywords, locationName and distanceFromLocation are used.
  * @return {Object} Returns a Encoded and sanitised query string, and also an object version.
  */
@@ -19,10 +19,8 @@ const prepareQuery = (query) => {
 
   cleanQuery.keywords = cleanseKeywords(cleanQuery.keywords);
 
-  // Validate location exists in pre-defined list, if not default to london
-  if (!permittedLocations.includes(cleanQuery.locationName.toLowerCase())) cleanQuery.locationName = 'london';
+  cleanQuery.locationName = cleanseLocation(cleanQuery.locationName);
 
-  // Encoded query
   const queryToEncode = `keywords=${cleanQuery.keywords}&locationName=${
     cleanQuery.locationName}&distanceFromLocation=${cleanQuery.distanceFromLocation}`;
 
@@ -65,6 +63,19 @@ const cleanseKeywords = (keywords) => {
   keywordsToReturn = keywordsToReturn.trim();
 
   return keywordsToReturn;
+};
+
+/**
+ * Check if the location is in the list of permitted locations, otherwise default it to London
+ * @param {String} location A location string as supplied by the user
+ * @return {String} Returns a default location or the supplied location if it is permitted
+ */
+const cleanseLocation = (location) => {
+  if (!permittedLocations.includes(location.toLowerCase())) {
+    return 'london';
+  }
+
+  return location;
 };
 
 /**


### PR DESCRIPTION
In an effort to simplify and make the code more readable, I've re-written elements of the Search Services. Key changes are:

- Introduction of axios, simplifying the API call to reed
- Broke out multiple elements within prepareQuery to functions

Per below, confirmed tests are passing.

**Test output:**
Search Services
    GET /api/jobs/search
      ✓ the number of jobs available is returned when the search route is called (272ms)
      searchReed()
        ✓ jobs are returned when an api call is made to reed.co.uk (206ms)
      prepareQuery()
        ✓ locations that are not permitted are replaced with london
        ✓ permitted locations are not replaced with london
        ✓ keywords that are not permitted are removed
        ✓ distance must be an int, floats are converted to int and NaNs are defaulted to 10
